### PR TITLE
Allow more repositories to be followed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,17 @@ lgtm:
 ## Commands
 
 ```bash
-# Finds all repositories for a specified Github organization and adds them to your LGTM's account's project list. (note: this will only follow repos that contain Kotlin, Java, and Groovy languages).
-python3 follow_org.py GITHUB_ORG_TO_FOLLOW
+# Finds all repositories for a specified Github organization and adds them to your LGTM's account's project list.
+#
+# For example, if you want to add repositories that use Java and Kotlin:
+# python3 follow_org.py netflix Java,Kotlin
+#
+# If you want to find all CodeQL-supported repositories regardless of the language used,
+# don't provide a second argument in the command:
+# python3 follow_org.py netflix
+#
+python3 follow_org.py GITHUB_ORG_TO_FOLLOW LANGUAGES_SUPPORTED
+
 
 # Finds all repositories for a specified Github organization and unfollows them from your LGTM account's project list.
 python3 unfollow_org.py GITHUB_ORG_TO_UNFOLLOW

--- a/follow_org.py
+++ b/follow_org.py
@@ -15,7 +15,7 @@ def create_github() -> Github:
 
 
 def get_languages() -> List[str]:
-    default_languages = [
+    default_languages: List[str] = [
         'Kotlin',
         'Groovy',
         'Java',
@@ -28,10 +28,12 @@ def get_languages() -> List[str]:
         'Go'
     ]
 
-    # If the user does not provide a value to filter languages, we look for all
-    # projects for all languages
+    # If the user does not want to follow repos using a specific language(s), we
+    # follow all repos that are CodeQL supported instead.
     if len(sys.argv) >= 3:
-        return sys.argv[2].split(',')
+        languages = sys.argv[2].split(',')
+        formatted_languages = [language.capitalize() for language in languages]
+        return formatted_languages
     else:
         return default_languages
 
@@ -43,8 +45,8 @@ def load_repository_list(org: str) -> List[str]:
 
     repos_to_load: List[str] = []
     for repo in repos:
-        if repo.archived or repo.fork
-            continue;
+        if repo.archived or repo.fork:
+            continue
         if repo.language in languages:
             print("Adding: " + repo.full_name)
             repos_to_load.append(repo.full_name)

--- a/follow_org.py
+++ b/follow_org.py
@@ -14,13 +14,38 @@ def create_github() -> Github:
         return Github(github['api_key'])
 
 
+def get_languages() -> List[str]:
+    default_languages = [
+        'Kotlin',
+        'Groovy',
+        'Java',
+        'C#',
+        'C',
+        'C++',
+        'Python',
+        'Javascript',
+        'TypeScript',
+        'Go'
+    ]
+
+    # If the user does not provide a value to filter languages, we look for all
+    # projects for all languages
+    if len(sys.argv) >= 3:
+        return sys.argv[2].split(',')
+    else:
+        return default_languages
+
+
 def load_repository_list(org: str) -> List[str]:
+    languages = get_languages()
     github = create_github()
     repos = github.get_organization(org).get_repos(type='public')
 
     repos_to_load: List[str] = []
     for repo in repos:
-        if not repo.archived and not repo.fork and repo.language in ['Kotlin', 'Groovy', 'Java']:
+        if repo.archived or repo.fork
+            continue;
+        if repo.language in languages:
             print("Adding: " + repo.full_name)
             repos_to_load.append(repo.full_name)
 


### PR DESCRIPTION
## What Does This PR Do
Right now when a user wants to follow all repos for a given Github organization, only repositories that support Java, Groovy, and Katlin are followed.

This PR updates the follow_org.py script in two ways:

1. Allow users to specify which languages they want to follow. 
2. If no language is provided, the default option will be every CodeQL supported language.

## How Did You Test This
- Ran `python3 follow_org.py netflix`. The output looked fine. I then view my lgtm.com account and see all Netflix repos were added to my account.
- Ran `python3 follow_org.py square c#`. The output looked fine. I then view my lgtm.com account and saw two Square repositories added. [Confirmed](https://github.com/square?language=csharp) that there are only two C# repos in the Square organization.


## Anything Else We Should Know
As far as I can tell, there are no strong rules on how we should handle user input in the command line. In this PR, I've set the precedent that multiple values should be delineated as `<item>,<item>,<item>` when providing input in a command line argument. I do not know how you feel about this. I'm more than happy to change something to better fit what you think works.