### PR TITLE
Add fork:false to Github queries

### DIFF
--- a/follow_repos_by_search_term.py
+++ b/follow_repos_by_search_term.py
@@ -22,7 +22,7 @@ def find_and_save_projects_to_lgtm(language: str, search_term: str):
     site = LGTMSite.create_from_file()
 
     for date_range in utils.github_dates.generate_dates():
-        repos = github.search_repositories(query=f'language:{language} created:{date_range} {search_term}')
+        repos = github.search_repositories(query=f'language:{language} fork:false created:{date_range} {search_term}')
 
         for repo in repos:
             # Github has rate limiting in place hence why we add a sleep here. More info can be found here:

--- a/follow_top_repos_by_star_count.py
+++ b/follow_top_repos_by_star_count.py
@@ -22,7 +22,7 @@ def find_and_save_projects_to_lgtm(language: str):
     site = LGTMSite.create_from_file()
 
     for date_range in utils.github_dates.generate_dates():
-        repos = github.search_repositories(query=f'stars:>500 created:{date_range} sort:stars language:{language}')
+        repos = github.search_repositories(query=f'stars:>500 created:{date_range} fork:false sort:stars language:{language}')
 
         for repo in repos:
             # Github has rate limiting in place hence why we add a sleep here. More info can be found here:


### PR DESCRIPTION
Fixes #8 

## What does this PR do

This PR adds `fork:false` to Github queries since lgtm.com will not scan forked repos.

## Anything Else We Should Know
I did not test this since the change was simple.